### PR TITLE
Added a simple moves pending badge

### DIFF
--- a/background.html
+++ b/background.html
@@ -13,6 +13,8 @@
 	    sendResponse({style: localStorage.style});
 	else if (request.localstorage == "reversiStyle")
 	    sendResponse({green: localStorage.background, go: localStorage.go});
+        else if (request.localstorage == "badgeUpdate")
+            setBadge(request.data);
         else
             sendResponse({});
     }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     },
     "content_scripts": [
         {
-            "matches": ["http://www.littlegolem.net/jsp/game/game.jsp*"],
+            "matches": ["http://www.littlegolem.net/jsp/game/*"],
             "js": ["lib/jquery.js", "src/shogi_piece_set.js",
                    "src/reversi_style.js", "src/requests.js"],
             "run_at": "document_end"

--- a/src/requests.js
+++ b/src/requests.js
@@ -14,3 +14,5 @@ if (game_name.indexOf("Shogi") >= 0) {
 			set_style(response.style);
 		});
 }
+
+chrome.extension.sendRequest({localstorage: "badgeUpdate", data: $("body").html()});


### PR DESCRIPTION
It's simple because it polls every 30 seconds and also updates whenever you go to a http://www.littlegolem.net/jsp/game/* url.  It would be nice if it could look at all little golem pages and detect the Your games text link.  I will probably end up adding this in the future.

Also, personal preference of mine.  It'd be nicer if the icon took me to my games page instead of opening a config.  I like the idea of clicking the icon to do something with little golem instead of managing something to do with little golem (that's what right click->Options is for).
