### PR TITLE
Fix broken "Go" Hex board design in LG

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Bigger Golem",
     "manifest_version": 2,
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "An extension to enhance the Little Golem experience.",
     "applications": {
       "gecko": {
@@ -23,7 +23,7 @@
             "matches": ["*://*.littlegolem.net/jsp/game/*"],
             "js": ["lib/jquery-3.2.1.min.js", "src/shogi_piece_set.js",
                    "src/go_style.js", "src/chess_style.js",
-                   "src/reversi_style.js", "src/requests.js", "src/options.js"],
+                   "src/reversi_style.js", "src/hex_style.js", "src/requests.js", "src/options.js"],
             "run_at": "document_end"
         }
     ],

--- a/src/hex_style.js
+++ b/src/hex_style.js
@@ -1,0 +1,40 @@
+function fixBrokenHexBoard() {
+  var emptyLinks = $('svg a:empty');
+
+  if (emptyLinks.length == 0) {
+    return;
+  }
+
+  var lines = $('svg line[style*="stroke-width:.5"]');
+  var size = lines.length / 4;
+
+  var minX = 999999, minY = 999999, maxX = 0, maxY = 0;
+  var coordBase = 'a'.charCodeAt(0);
+  var currentPage = window.location.href;
+
+  lines.each(function() {
+    minX = Math.min(minX, this.x1.baseVal.value, this.x2.baseVal.value);
+    maxX = Math.max(maxX, this.x1.baseVal.value, this.x2.baseVal.value);
+    minY = Math.min(minY, this.y1.baseVal.value, this.y2.baseVal.value);
+    maxY = Math.max(maxY, this.y1.baseVal.value, this.y2.baseVal.value);
+  });
+
+  var midX = (minX + maxX) / 2;
+  var midY = (minY + maxY) / 2;
+
+  $('svg a:empty').each(function() {
+    let coords = this.href.baseVal.substr(-2);
+    let x = coords.charCodeAt(0) - coordBase, y = coords.charCodeAt(1) - coordBase;
+
+    targetX = minX + y * (midX - minX) / (size - 1) + x * (midX - minX) / (size - 1);
+    targetY = midY + y * (maxY - midY) / (size - 1) - x * (maxY - midY) / (size - 1);
+
+    let tx = String.fromCharCode(coordBase + x), ty = String.fromCharCode(coordBase + y);
+
+    $('svg').append('<a href="' + currentPage + "&move=" + tx + ty + '"><circle cx="' + targetX + '" cy="' + targetY + '" r="' + (0.5 * (midX - minX) / (size - 1)) + '" fill="none" style="pointer-events: fill"/></a>');
+  });
+
+  $('svg a:empty').remove();
+
+  $('svg').html($('svg').html());
+}

--- a/src/requests.js
+++ b/src/requests.js
@@ -37,6 +37,8 @@ if (game_name.indexOf("Reversi") >= 0) {
   }, function(items) {
     chess_style(items.chess_pieces, items.chess_size);
   });
+} else if (game_name.indexOf("Hex") >= 0) {
+  fixBrokenHexBoard();
 }
 
 chrome.runtime.sendMessage({action: "badgeUpdate", data: $("body").html()});


### PR DESCRIPTION
Fixes a bug reported to me by David J Bush.

For some reason, the built-in "Go-like" hex board in LG is broken - none of the intersections are clickable, so you can't make a move while using it. This fixes that.

I didn't bother putting an option to enable this, since I can't imagine any scenario where you would want to disable this fix. If you're not using this design scheme, it won't do anything anyway, and if you are, I assume you want to be able to make a move.