### PR TITLE
Fix Hex SGFs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BiggerGolem.zip: manifest.json
-	zip -r BiggerGolem.zip * -x Makefile README.md greasemonkey/ .git/ .gitignore
+	zip -r BiggerGolem.zip * -x Makefile README.md greasemonkey/ greasemonkey/* tags
 
 greasemonkey/lg.js: 
 	cat "greasemonkey/header" "greasemonkey/config.js" "src/chess_style.js" "src/go_style.js" "src/shogi_style.js" "src/reversi_style.js" "src/hex_style.js" "greasemonkey/main.js" > greasemonkey/lg.js

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Bigger Golem is an extension that aims to bring a variety of improvements to the
 - Configurable (and resizable) piece sets and board color for Reversi (contributed by [Trevor Cook](https://github.com/tdcook))
 - Coordinates for Go boards (contributed by [Mathijs Claassen](https://github.com/mathijsclaassen))
 - Fix for broken Hex board design scheme
+- Fix for broken Hex SGF download
 - Head-to-head statistics for every player (contributed by [Mathijs Claassen](https://github.com/mathijsclaassen))
 
 More features are under active development.

--- a/greasemonkey/lg.js
+++ b/greasemonkey/lg.js
@@ -253,6 +253,46 @@ function fixBrokenHexBoard() {
 
   $('svg').html($('svg').html());
 }
+
+function fixHexSgf() {
+  function convertToSgf(moves) {
+    var players = $('.portlet.box.yellow .portlet-body .col-xs-6.col-md-6 a')
+    
+    var sgf = "(;FF[4]PB[" +
+      players[0].text.replace(" ★", "") +
+      "]PW[" +
+      players[1].text.replace(" ★", "") +
+      "]SZ[" +
+      /Hex.*-Size (\d+)/.exec($(".page-title").text())[1] +
+      "]SO[http://www.littlegolem.com]";
+    var swap = 0;
+
+    if (moves.length > 1 && moves[1].indexOf('swap') >= 0) {
+      // This is a hack to deal with the fact that none of the Hex SGF editors I've ever seen properly
+      // implement swap-pieces. So we just hardcode the swap into the SGF.
+      swap = 1;
+    }
+      
+    for (var i = 0; i < moves.length; i++) {
+      console.log(i);
+      if (swap == 1 && i == 0) {
+        sgf += ";" + "W[" + String.fromCharCode('a'.charCodeAt(0) + (moves[0][3].charCodeAt(0) - '1'.charCodeAt(0))) + (moves[0][2].charCodeAt(0) - 'a'.charCodeAt(0) + 1) + "]" +
+          "C[This was actually a swap move played by black]";
+        i += 1;
+      } else {
+        sgf += ";" + (i % 2 == 0 ? "B" : "W") + "[" + moves[i].substring(moves[i].indexOf(".") + 1) + "]";
+      }
+    }
+    
+    sgf += ")";
+    
+    return btoa(sgf);
+  }
+  
+  $('.caption:contains(Move List) + .actions a')
+      .attr('download', 'game' + new URLSearchParams(window.location.search).get("gid") + ".hsgf")
+      .attr('href', 'data:application/x-hex-sgf;base64,' + convertToSgf($('.caption:contains(Move List)').parents('.portlet').find('.portlet-body a,span').map(function(x) { return $(this).text(); }).get()));
+}
 (function() {
     'use strict';
 

--- a/greasemonkey/lg.js
+++ b/greasemonkey/lg.js
@@ -325,5 +325,8 @@ function fixHexSgf() {
         setChessStyle(CHESS_STYLE, CHESS_SIZE);
     } else if (game_name.indexOf('Hex') >= 0) {
         fixBrokenHexBoard();
+        setTimeout(function() {
+          fixHexSgf();
+        }, 600);
     }
 })();

--- a/greasemonkey/main.js
+++ b/greasemonkey/main.js
@@ -30,5 +30,8 @@
         setChessStyle(CHESS_STYLE, CHESS_SIZE);
     } else if (game_name.indexOf('Hex') >= 0) {
         fixBrokenHexBoard();
+        setTimeout(function() {
+          fixHexSgf();
+        }, 600);
     }
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Bigger Golem",
     "manifest_version": 2,
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "An extension to enhance the Little Golem experience.",
     "applications": {
         "gecko": {

--- a/src/hex_style.js
+++ b/src/hex_style.js
@@ -38,3 +38,29 @@ function fixBrokenHexBoard() {
 
   $('svg').html($('svg').html());
 }
+
+function fixHexSgf() {
+  function convertToSgf(moves) {
+    var players = $('.portlet.box.yellow .portlet-body .col-xs-6.col-md-6 a')
+    
+    var sgf = "(;FF[4]PB[" +
+      players[0].text.replace(" ★", "") +
+      "]PW[" +
+      players[1].text.replace(" ★", "") +
+      "]SZ[" +
+      /Hex-Size (\d+)/.exec($(".page-title").text())[1] +
+      "]SO[http://www.littlegolem.com]"
+      
+      for (var i = 0; i < moves.length; i++) {
+        sgf += ";" + (i % 2 == 0 ? "B" : "W") + "[" + moves[i].substring(moves[i].indexOf(".") + 1) + "]";
+      }
+      
+      sgf += ")";
+      
+      return btoa(sgf);
+  }
+  
+  $('.caption:contains(Move List) + .actions a')
+      .attr('download', 'game' + new URLSearchParams(window.location.search).get("gid") + ".hsgf")
+      .attr('href', 'data:application/x-hex-sgf;base64,' + convertToSgf($('.caption:contains(Move List)').parents('.portlet').find('.portlet-body a,span').map(function(x) { return $(this).text(); }).get()));
+}

--- a/src/hex_style.js
+++ b/src/hex_style.js
@@ -48,16 +48,30 @@ function fixHexSgf() {
       "]PW[" +
       players[1].text.replace(" ★", "") +
       "]SZ[" +
-      /Hex-Size (\d+)/.exec($(".page-title").text())[1] +
-      "]SO[http://www.littlegolem.com]"
+      /Hex.*-Size (\d+)/.exec($(".page-title").text())[1] +
+      "]SO[http://www.littlegolem.com]";
+    var swap = 0;
+
+    if (moves.length > 1 && moves[1].indexOf('swap') >= 0) {
+      // This is a hack to deal with the fact that none of the Hex SGF editors I've ever seen properly
+      // implement swap-pieces. So we just hardcode the swap into the SGF.
+      swap = 1;
+    }
       
-      for (var i = 0; i < moves.length; i++) {
+    for (var i = 0; i < moves.length; i++) {
+      console.log(i);
+      if (swap == 1 && i == 0) {
+        sgf += ";" + "W[" + String.fromCharCode('a'.charCodeAt(0) + (moves[0][3].charCodeAt(0) - '1'.charCodeAt(0))) + (moves[0][2].charCodeAt(0) - 'a'.charCodeAt(0) + 1) + "]" +
+          "C[This was actually a swap move played by black]";
+        i += 1;
+      } else {
         sgf += ";" + (i % 2 == 0 ? "B" : "W") + "[" + moves[i].substring(moves[i].indexOf(".") + 1) + "]";
       }
-      
-      sgf += ")";
-      
-      return btoa(sgf);
+    }
+    
+    sgf += ")";
+    
+    return btoa(sgf);
   }
   
   $('.caption:contains(Move List) + .actions a')

--- a/src/requests.js
+++ b/src/requests.js
@@ -42,6 +42,9 @@ if (game_name.indexOf('Reversi') >= 0) {
   });
 } else if (game_name.indexOf('Hex') >= 0) {
   fixBrokenHexBoard();
+  setTimeout(function() {
+    fixHexSgf();
+  }, 600);
 }
 
 setTimeout(function() {


### PR DESCRIPTION
Hex SGFs on LG _look_ valid but are actually pretty broken, in particular B/W are swapped. This fixes it and generates a clean, HexGui-compatible SGF.

The one trick was the swap move, which HexGui does not actually implement correctly. I worked around this by just manually doing the swap and replacing it with White's first move (and a comment explaining that a swap occurred). Not ideal, but at least no real information is lost.